### PR TITLE
added branding icon and color

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,9 @@
 name: 'Autometrics Diff Metrics'
 description: 'Check the difference in autometrics coverage between the source and the target of a Pull Request.'
 author: 'autometrics-dev'
+branding:
+  icon: 'bar-chart'
+  color: 'purple'
 inputs:
   gh-token:
     description: 'Github token to use'


### PR DESCRIPTION
this PR adds a color and icon according to the GitHub Action branding guidelines:

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#branding

also see this cheatsheet:
https://github.com/haya14busa/github-action-brandings