### PR TITLE
Use node 20 for the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,5 +28,5 @@ inputs:
     description: 'The version of am to download, skip patch or minor to act as a wildcard. "0.2" means ">=0.2.0 && <0.3.0", "1" means ">=1.0.0 && <2.0.0", etc.'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Blocked by https://github.com/actions/runner/issues/2619

Also, GIthub is skipping Node18 altogether, so we need to to node20 instead.

Retry by the end of Week  33